### PR TITLE
Refresh platforms + fixed RotationEventEffect

### DIFF
--- a/CustomFloorPlugin/Behaviour Descriptors/PairRotationEventEffect.cs
+++ b/CustomFloorPlugin/Behaviour Descriptors/PairRotationEventEffect.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace CustomFloorPlugin {
+    class PairRotationEventEffect:MonoBehaviour {
+#pragma warning disable CS0649
+        public SongEventType eventTypeL;
+        public SongEventType eventTypeR;
+        public Vector3 rotationVector;
+        public float startRotation;
+        public Transform transformL;
+        public Transform transformR;
+#pragma warning restore CS0649
+    }
+}

--- a/CustomFloorPlugin/Behaviour Managers/PairRotationEventEffectManager.cs
+++ b/CustomFloorPlugin/Behaviour Managers/PairRotationEventEffectManager.cs
@@ -1,0 +1,114 @@
+using BS_Utils.Utilities;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Harmony;
+using System.Reflection;
+
+
+namespace CustomFloorPlugin {
+    public class PairRotationEventEffectManager:MonoBehaviour {
+        List<PairRotationEventEffect> effectDescriptors;
+        List<LightPairRotationEventEffect> lightRotationEffects;
+
+        internal void RegisterForEvents() {
+            BSEvents.menuSceneLoaded += HandleSceneChange;
+            BSEvents.gameSceneLoaded += HandleSceneChange;
+            HandleSceneChange();
+        }
+
+        private void OnDisable() {
+            BSEvents.menuSceneLoaded -= HandleSceneChange;
+            BSEvents.gameSceneLoaded -= HandleSceneChange;
+            HandleSceneChange();
+        }
+
+        private void HandleSceneChange() {
+            Type RotationData = Type.GetType("LightPairRotationEventEffect+RotationData,MainAssembly");
+            MethodInfo GetPrivateFieldM = typeof(ReflectionUtil).GetMethod("GetPrivateField", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(object), typeof(string) }, null);
+            GetPrivateFieldM = GetPrivateFieldM.MakeGenericMethod(RotationData);
+
+            foreach (LightPairRotationEventEffect rotEffect in lightRotationEffects) {
+                Vector3 rotationVector = ReflectionUtil.GetPrivateField<Vector3>(rotEffect, "_rotationVector");
+                float startRotation = ReflectionUtil.GetPrivateField<float>(rotEffect, "_startRotation");
+
+                var rotationDataL = GetPrivateFieldM.Invoke(null, new object[]{ rotEffect, "_rotationDataL" });
+                if (rotationDataL != null) {
+                    Transform transformL = rotationDataL.GetField<Transform>("transform");
+                    transformL.localRotation = rotationDataL.GetField<Quaternion>("startRotation");
+                    transformL.Rotate(rotationVector, -startRotation, Space.Self);
+                }
+
+                var rotationDataR = GetPrivateFieldM.Invoke(null, new object[] { rotEffect, "_rotationDataR" });
+                if (rotationDataR != null) {
+                    Transform transformR = rotationDataR.GetField<Transform>("transform");
+                    transformR.localRotation = rotationDataR.GetField<Quaternion>("startRotation");
+                    transformR.Rotate(rotationVector, startRotation, Space.Self);
+                }
+
+                rotEffect.enabled = true;
+            }
+        }
+
+        public void CreateEffects(GameObject go) {
+            if(lightRotationEffects == null) lightRotationEffects = new List<LightPairRotationEventEffect>();
+            if(effectDescriptors == null) effectDescriptors = new List<PairRotationEventEffect>();
+
+            PairRotationEventEffect[] localDescriptors = go.GetComponentsInChildren<PairRotationEventEffect>(true);
+
+            if(localDescriptors == null) return;
+
+            BeatmapObjectCallbackController[] beatmapObjectCallbackControllers = (BeatmapObjectCallbackController[]) GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController));
+
+            foreach(PairRotationEventEffect effectDescriptor in localDescriptors) {
+                LightPairRotationEventEffect rotEvent = effectDescriptor.gameObject.AddComponent<LightPairRotationEventEffect>();
+                PlatformManager.SpawnedComponents.Add(rotEvent);
+
+                ReflectionUtil.SetPrivateField(rotEvent, "_eventL", (BeatmapEventType)effectDescriptor.eventTypeL);
+                ReflectionUtil.SetPrivateField(rotEvent, "_eventR", (BeatmapEventType)effectDescriptor.eventTypeR);
+                ReflectionUtil.SetPrivateField(rotEvent, "_rotationVector", effectDescriptor.rotationVector);
+                ReflectionUtil.SetPrivateField(rotEvent, "_overrideRandomValues", false);
+                ReflectionUtil.SetPrivateField(rotEvent, "_startRotation", effectDescriptor.startRotation);
+                ReflectionUtil.SetPrivateField(rotEvent, "_transformL", effectDescriptor.transformL);
+                ReflectionUtil.SetPrivateField(rotEvent, "_transformR", effectDescriptor.transformR);
+                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackControllers[0]);
+                lightRotationEffects.Add(rotEvent);
+                effectDescriptors.Add(effectDescriptor);
+            }
+        }
+    }
+}
+
+namespace CustomFloorPlugin.HarmonyPatches {
+    [HarmonyPatch(typeof(LightPairRotationEventEffect), "Start")]
+    class LightPairRotationEventEffectStartPatch {
+        static bool Prefix(LightPairRotationEventEffect __instance) {
+            ReflectionUtil.GetPrivateField<BeatmapObjectCallbackController>(__instance, "_beatmapObjectCallbackController").beatmapEventDidTriggerEvent += __instance.HandleBeatmapObjectCallbackControllerBeatmapEventDidTrigger;
+
+            Vector3 rotationVector = ReflectionUtil.GetPrivateField<Vector3>(__instance, "_rotationVector");
+            float startRotation = ReflectionUtil.GetPrivateField<float>(__instance, "_startRotation");
+            ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL").transform.Rotate(rotationVector, startRotation, Space.Self);
+            ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR").transform.Rotate(rotationVector, -startRotation, Space.Self);
+
+            Type RotationData = Type.GetType("LightPairRotationEventEffect+RotationData,MainAssembly");
+
+            var rotationDataL = Activator.CreateInstance(RotationData);
+            rotationDataL.SetField("enabled", false);
+            rotationDataL.SetField("rotationSpeed", 0f);
+            rotationDataL.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL").localRotation); // thank you Beat Games for using the global rotation
+            rotationDataL.SetField("transform", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL"));
+            ReflectionUtil.SetPrivateField(__instance, "_rotationDataL", rotationDataL);
+
+            var rotationDataR = Activator.CreateInstance(RotationData);
+            rotationDataR.SetField("enabled", false);
+            rotationDataR.SetField("rotationSpeed", 0f);
+            rotationDataR.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR").localRotation);
+            rotationDataR.SetField("transform", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR"));
+            ReflectionUtil.SetPrivateField(__instance, "_rotationDataR", rotationDataR);
+
+            __instance.enabled = false;
+
+            return false;
+        }
+    }
+}

--- a/CustomFloorPlugin/Behaviour Managers/PairRotationEventEffectManager.cs
+++ b/CustomFloorPlugin/Behaviour Managers/PairRotationEventEffectManager.cs
@@ -23,8 +23,14 @@ namespace CustomFloorPlugin {
             HandleSceneChange();
         }
 
+        /// <summary>
+        /// Resets the rotation of every LightPairRotationEventEffect to its original rotation, so it's ready for the next level.
+        /// </summary>
         private void HandleSceneChange() {
+            // Since LightPairRotationEventEffect.RotationData is a private internal member, we need to get its type dynamically.
             Type RotationData = Type.GetType("LightPairRotationEventEffect+RotationData,MainAssembly");
+
+            // The reflection method to get the rotation data must have its generic method created dynamically, so as to use the dynamic type.
             MethodInfo GetPrivateFieldM = typeof(ReflectionUtil).GetMethod("GetPrivateField", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(object), typeof(string) }, null);
             GetPrivateFieldM = GetPrivateFieldM.MakeGenericMethod(RotationData);
 
@@ -32,17 +38,26 @@ namespace CustomFloorPlugin {
                 Vector3 rotationVector = ReflectionUtil.GetPrivateField<Vector3>(rotEffect, "_rotationVector");
                 float startRotation = ReflectionUtil.GetPrivateField<float>(rotEffect, "_startRotation");
 
+                // Reset the rotation of the objects.
                 var rotationDataL = GetPrivateFieldM.Invoke(null, new object[]{ rotEffect, "_rotationDataL" });
                 if (rotationDataL != null) {
                     Transform transformL = rotationDataL.GetField<Transform>("transform");
+
+                    // Restore the start rotation of the object.
                     transformL.localRotation = rotationDataL.GetField<Quaternion>("startRotation");
+
+                    // Undo the rotation applied by default, so the object is back to its initial rotation.
                     transformL.Rotate(rotationVector, -startRotation, Space.Self);
                 }
 
                 var rotationDataR = GetPrivateFieldM.Invoke(null, new object[] { rotEffect, "_rotationDataR" });
                 if (rotationDataR != null) {
                     Transform transformR = rotationDataR.GetField<Transform>("transform");
+
+                    // Restore the start rotation of the object.
                     transformR.localRotation = rotationDataR.GetField<Quaternion>("startRotation");
+
+                    // Undo the rotation applied by default, so the object is back to its initial rotation.
                     transformR.Rotate(rotationVector, startRotation, Space.Self);
                 }
 
@@ -58,12 +73,14 @@ namespace CustomFloorPlugin {
 
             if(localDescriptors == null) return;
 
-            BeatmapObjectCallbackController[] beatmapObjectCallbackControllers = (BeatmapObjectCallbackController[]) GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController));
+            // Get the BeatmapObjectCallbackController floating in the level.
+            BeatmapObjectCallbackController beatmapObjectCallbackController = ((BeatmapObjectCallbackController[])GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController)))[0];
 
-            foreach(PairRotationEventEffect effectDescriptor in localDescriptors) {
+            foreach (PairRotationEventEffect effectDescriptor in localDescriptors) {
                 LightPairRotationEventEffect rotEvent = effectDescriptor.gameObject.AddComponent<LightPairRotationEventEffect>();
                 PlatformManager.SpawnedComponents.Add(rotEvent);
 
+                // Convert the effect descriptor into the behaviour from the base game.
                 ReflectionUtil.SetPrivateField(rotEvent, "_eventL", (BeatmapEventType)effectDescriptor.eventTypeL);
                 ReflectionUtil.SetPrivateField(rotEvent, "_eventR", (BeatmapEventType)effectDescriptor.eventTypeR);
                 ReflectionUtil.SetPrivateField(rotEvent, "_rotationVector", effectDescriptor.rotationVector);
@@ -71,7 +88,7 @@ namespace CustomFloorPlugin {
                 ReflectionUtil.SetPrivateField(rotEvent, "_startRotation", effectDescriptor.startRotation);
                 ReflectionUtil.SetPrivateField(rotEvent, "_transformL", effectDescriptor.transformL);
                 ReflectionUtil.SetPrivateField(rotEvent, "_transformR", effectDescriptor.transformR);
-                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackControllers[0]);
+                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackController);
                 lightRotationEffects.Add(rotEvent);
                 effectDescriptors.Add(effectDescriptor);
             }
@@ -80,6 +97,10 @@ namespace CustomFloorPlugin {
 }
 
 namespace CustomFloorPlugin.HarmonyPatches {
+    /// <summary>
+    /// Bug in Beat Games code: The startRotation of every RotationData is set to transform.rotation, when it should be transform.localRotation.
+    /// To fix this bug, the entire function must be re-implemented in this harmony patch with the fix included.
+    /// </summary>
     [HarmonyPatch(typeof(LightPairRotationEventEffect), "Start")]
     class LightPairRotationEventEffectStartPatch {
         static bool Prefix(LightPairRotationEventEffect __instance) {
@@ -90,19 +111,20 @@ namespace CustomFloorPlugin.HarmonyPatches {
             ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL").transform.Rotate(rotationVector, startRotation, Space.Self);
             ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR").transform.Rotate(rotationVector, -startRotation, Space.Self);
 
+            // Since LightPairRotationEventEffect.RotationData is a private internal member, we need to get its type dynamically.
             Type RotationData = Type.GetType("LightPairRotationEventEffect+RotationData,MainAssembly");
 
             var rotationDataL = Activator.CreateInstance(RotationData);
             rotationDataL.SetField("enabled", false);
             rotationDataL.SetField("rotationSpeed", 0f);
-            rotationDataL.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL").localRotation); // thank you Beat Games for using the global rotation
+            rotationDataL.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL").localRotation); // This is the fix.
             rotationDataL.SetField("transform", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformL"));
             ReflectionUtil.SetPrivateField(__instance, "_rotationDataL", rotationDataL);
 
             var rotationDataR = Activator.CreateInstance(RotationData);
             rotationDataR.SetField("enabled", false);
             rotationDataR.SetField("rotationSpeed", 0f);
-            rotationDataR.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR").localRotation);
+            rotationDataR.SetField("startRotation", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR").localRotation); // This is the fix.
             rotationDataR.SetField("transform", ReflectionUtil.GetPrivateField<Transform>(__instance, "_transformR"));
             ReflectionUtil.SetPrivateField(__instance, "_rotationDataR", rotationDataR);
 

--- a/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
+++ b/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
@@ -2,7 +2,6 @@ using BS_Utils.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
 using Harmony;
-using System.Reflection.Emit;
 
 
 namespace CustomFloorPlugin {

--- a/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
+++ b/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
@@ -1,6 +1,8 @@
 using BS_Utils.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
+using Harmony;
+using System.Reflection.Emit;
 
 
 namespace CustomFloorPlugin {
@@ -9,26 +11,21 @@ namespace CustomFloorPlugin {
         List<LightRotationEventEffect> lightRotationEffects;
 
         internal void RegisterForEvents() {
-            foreach(LightRotationEventEffect rotEffect in lightRotationEffects) {
-                BSEvents.beatmapEvent += rotEffect.HandleBeatmapObjectCallbackControllerBeatmapEventDidTrigger;
-            }
             BSEvents.menuSceneLoaded += HandleSceneChange;
             BSEvents.gameSceneLoaded += HandleSceneChange;
             HandleSceneChange();
         }
 
         private void OnDisable() {
-            foreach(LightRotationEventEffect rotEffect in lightRotationEffects) {
-                BSEvents.beatmapEvent -= rotEffect.HandleBeatmapObjectCallbackControllerBeatmapEventDidTrigger;
-            }
             BSEvents.menuSceneLoaded -= HandleSceneChange;
             BSEvents.gameSceneLoaded -= HandleSceneChange;
+            HandleSceneChange();
         }
 
         private void HandleSceneChange() {
             foreach(LightRotationEventEffect rotEffect in lightRotationEffects) {
                 rotEffect.transform.localRotation = ReflectionUtil.GetPrivateField<Quaternion>(rotEffect, "_startRotation");
-                rotEffect.enabled = false;
+                rotEffect.enabled = true;
             }
         }
 
@@ -40,17 +37,33 @@ namespace CustomFloorPlugin {
 
             if(localDescriptors == null) return;
 
-            foreach(RotationEventEffect effectDescriptor in effectDescriptors) {
+            BeatmapObjectCallbackController[] beatmapObjectCallbackControllers = (BeatmapObjectCallbackController[]) GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController));
+
+            foreach(RotationEventEffect effectDescriptor in localDescriptors) {
                 LightRotationEventEffect rotEvent = effectDescriptor.gameObject.AddComponent<LightRotationEventEffect>();
                 PlatformManager.SpawnedComponents.Add(rotEvent);
 
                 ReflectionUtil.SetPrivateField(rotEvent, "_event", (BeatmapEventType)effectDescriptor.eventType);
                 ReflectionUtil.SetPrivateField(rotEvent, "_rotationVector", effectDescriptor.rotationVector);
+                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackControllers[0]);
                 ReflectionUtil.SetPrivateField(rotEvent, "_transform", rotEvent.transform);
-                ReflectionUtil.SetPrivateField(rotEvent, "_startRotation", rotEvent.transform.rotation);
+                ReflectionUtil.SetPrivateField(rotEvent, "_startRotation", rotEvent.transform.localRotation);
                 lightRotationEffects.Add(rotEvent);
                 effectDescriptors.Add(effectDescriptor);
             }
+        }
+    }
+}
+
+namespace CustomFloorPlugin.HarmonyPatches {
+    [HarmonyPatch(typeof(LightRotationEventEffect), "Start")]
+    class LightRotationEventEffectStartPatch {
+        static bool Prefix(LightRotationEventEffect __instance) {
+            ReflectionUtil.GetPrivateField<BeatmapObjectCallbackController>(__instance, "_beatmapObjectCallbackController").beatmapEventDidTriggerEvent += __instance.HandleBeatmapObjectCallbackControllerBeatmapEventDidTrigger;
+            ReflectionUtil.SetPrivateField(__instance, "_transform", __instance.transform);
+            ReflectionUtil.SetPrivateField(__instance, "_startRotation", __instance.transform.localRotation); // thank you Beat Games for using the global rotation
+            __instance.enabled = false;
+            return false;
         }
     }
 }

--- a/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
+++ b/CustomFloorPlugin/Behaviour Managers/RotationEventEffectManager.cs
@@ -21,9 +21,15 @@ namespace CustomFloorPlugin {
             HandleSceneChange();
         }
 
+        /// <summary>
+        /// Resets the rotation of every LightRotationEventEffect to its original rotation, so it's ready for the next level.
+        /// </summary>
         private void HandleSceneChange() {
-            foreach(LightRotationEventEffect rotEffect in lightRotationEffects) {
+            foreach (LightRotationEventEffect rotEffect in lightRotationEffects) {
+                // Restore the start rotation of the object.
                 rotEffect.transform.localRotation = ReflectionUtil.GetPrivateField<Quaternion>(rotEffect, "_startRotation");
+
+                // The effect needs to be enabled so its Start is called when the platform loads, and the _startRotation is saved properly.
                 rotEffect.enabled = true;
             }
         }
@@ -36,15 +42,17 @@ namespace CustomFloorPlugin {
 
             if(localDescriptors == null) return;
 
-            BeatmapObjectCallbackController[] beatmapObjectCallbackControllers = (BeatmapObjectCallbackController[]) GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController));
+            // Get the BeatmapObjectCallbackController floating in the level.
+            BeatmapObjectCallbackController beatmapObjectCallbackController = ((BeatmapObjectCallbackController[]) GameObject.FindObjectsOfType(typeof(BeatmapObjectCallbackController)))[0];
 
             foreach(RotationEventEffect effectDescriptor in localDescriptors) {
                 LightRotationEventEffect rotEvent = effectDescriptor.gameObject.AddComponent<LightRotationEventEffect>();
                 PlatformManager.SpawnedComponents.Add(rotEvent);
 
+                // Convert the effect descriptor into the behaviour from the base game.
                 ReflectionUtil.SetPrivateField(rotEvent, "_event", (BeatmapEventType)effectDescriptor.eventType);
                 ReflectionUtil.SetPrivateField(rotEvent, "_rotationVector", effectDescriptor.rotationVector);
-                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackControllers[0]);
+                ReflectionUtil.SetPrivateField(rotEvent, "_beatmapObjectCallbackController", beatmapObjectCallbackController);
                 ReflectionUtil.SetPrivateField(rotEvent, "_transform", rotEvent.transform);
                 ReflectionUtil.SetPrivateField(rotEvent, "_startRotation", rotEvent.transform.localRotation);
                 lightRotationEffects.Add(rotEvent);
@@ -55,13 +63,18 @@ namespace CustomFloorPlugin {
 }
 
 namespace CustomFloorPlugin.HarmonyPatches {
+    /// <summary>
+    /// Bug in Beat Games code: The _startRotation is set to transform.rotation, when it should be transform.localRotation.
+    /// To fix this bug, the entire function must be re-implemented in this harmony patch with the fix included.
+    /// </summary>
     [HarmonyPatch(typeof(LightRotationEventEffect), "Start")]
     class LightRotationEventEffectStartPatch {
         static bool Prefix(LightRotationEventEffect __instance) {
             ReflectionUtil.GetPrivateField<BeatmapObjectCallbackController>(__instance, "_beatmapObjectCallbackController").beatmapEventDidTriggerEvent += __instance.HandleBeatmapObjectCallbackControllerBeatmapEventDidTrigger;
             ReflectionUtil.SetPrivateField(__instance, "_transform", __instance.transform);
-            ReflectionUtil.SetPrivateField(__instance, "_startRotation", __instance.transform.localRotation); // thank you Beat Games for using the global rotation
+            ReflectionUtil.SetPrivateField(__instance, "_startRotation", __instance.transform.localRotation); // This is the fix.
             __instance.enabled = false;
+
             return false;
         }
     }

--- a/CustomFloorPlugin/CustomFloorPlugin.csproj
+++ b/CustomFloorPlugin/CustomFloorPlugin.csproj
@@ -90,9 +90,11 @@
   <ItemGroup>
     <Compile Include="Behaviour Descriptors\CameraVisibility.cs" />
     <Compile Include="Behaviour Descriptors\PrefabLightmapData.cs" />
+    <Compile Include="Behaviour Descriptors\PairRotationEventEffect.cs" />
     <Compile Include="Behaviour Descriptors\SpectrogramAnimationState.cs" />
     <Compile Include="Behaviour Descriptors\SpectrogramMaterial.cs" />
     <Compile Include="Behaviour Managers\CameraVisibilityManager.cs" />
+    <Compile Include="Behaviour Managers\PairRotationEventEffectManager.cs" />
     <Compile Include="Behaviour Managers\SpectrogramAnimationStateManager.cs" />
     <Compile Include="Behaviour Managers\SpectrogramMaterialManager.cs" />
     <Compile Include="Behaviours\SpectrogramColumns.cs" />

--- a/CustomFloorPlugin/PlatformLoader.cs
+++ b/CustomFloorPlugin/PlatformLoader.cs
@@ -147,10 +147,12 @@ namespace CustomFloorPlugin {
                 RotationEventEffectManager rotManager = root.GetComponent<RotationEventEffectManager>();
                 if(rotManager == null) {
                     rotManager = root.AddComponent<RotationEventEffectManager>();
+                    rotManager.CreateEffects(go);
                     rotManager.RegisterForEvents();
                     PlatformManager.SpawnedComponents.Add(rotManager);
+                } else {
+                    rotManager.CreateEffects(go);
                 }
-                rotManager.CreateEffects(go);
             }
 
             // Add a trackRing controller if there are track ring descriptors

--- a/CustomFloorPlugin/PlatformLoader.cs
+++ b/CustomFloorPlugin/PlatformLoader.cs
@@ -155,6 +155,20 @@ namespace CustomFloorPlugin {
                 }
             }
 
+            // Pair rotation effect manager
+            if(go.GetComponentInChildren<PairRotationEventEffect>(true) != null)
+            {
+                PairRotationEventEffectManager rotManager = root.GetComponent<PairRotationEventEffectManager>();
+                if (rotManager == null) {
+                    rotManager = root.AddComponent<PairRotationEventEffectManager>();
+                    rotManager.CreateEffects(go);
+                    rotManager.RegisterForEvents();
+                    PlatformManager.SpawnedComponents.Add(rotManager);
+                } else {
+                    rotManager.CreateEffects(go);
+                }
+            }
+
             // Add a trackRing controller if there are track ring descriptors
             if(go.GetComponentInChildren<TrackRings>(true) != null) {
                 foreach(TrackRings trackRings in go.GetComponentsInChildren<TrackRings>(true)) {

--- a/CustomFloorPlugin/UI/PlatformListFlowCoordinator.cs
+++ b/CustomFloorPlugin/UI/PlatformListFlowCoordinator.cs
@@ -32,6 +32,10 @@ namespace CustomFloorPlugin.UI {
             var mainFlow = BeatSaberUI.MainFlowCoordinator;
             mainFlow.InvokePrivateMethod("DismissFlowCoordinator", this, null, false);
         }
+
+        /// <summary>
+        /// Updates the UI in the custom platforms menu with the currently loaded platforms.
+        /// </summary>
         public void RefreshPlatformsList()
         {
             _platformsListView.RefreshPlatformsList();

--- a/CustomFloorPlugin/UI/PlatformListFlowCoordinator.cs
+++ b/CustomFloorPlugin/UI/PlatformListFlowCoordinator.cs
@@ -32,5 +32,9 @@ namespace CustomFloorPlugin.UI {
             var mainFlow = BeatSaberUI.MainFlowCoordinator;
             mainFlow.InvokePrivateMethod("DismissFlowCoordinator", this, null, false);
         }
+        public void RefreshPlatformsList()
+        {
+            _platformsListView.RefreshPlatformsList();
+        }
     }
 }

--- a/CustomFloorPlugin/UI/PlatformsListView.cs
+++ b/CustomFloorPlugin/UI/PlatformsListView.cs
@@ -36,6 +36,10 @@ namespace CustomFloorPlugin.UI {
         internal void SetupPlatformsList() {
             RefreshPlatformsList();
         }
+
+        /// <summary>
+        /// Updates the UI in the custom platforms menu with the currently loaded platforms.
+        /// </summary>
         public void RefreshPlatformsList() {
             customListTableData.data.Clear();
             foreach(CustomPlatform platform in PlatformManager.Instance.GetPlatforms()) {

--- a/CustomFloorPlugin/UI/PlatformsListView.cs
+++ b/CustomFloorPlugin/UI/PlatformsListView.cs
@@ -34,6 +34,9 @@ namespace CustomFloorPlugin.UI {
 
         [UIAction("#post-parse")]
         internal void SetupPlatformsList() {
+            RefreshPlatformsList();
+        }
+        public void RefreshPlatformsList() {
             customListTableData.data.Clear();
             foreach(CustomPlatform platform in PlatformManager.Instance.GetPlatforms()) {
                 customListTableData.data.Add(new CustomListTableData.CustomCellInfo(platform.platName, platform.platAuthor, platform.icon.texture));

--- a/CustomFloorPlugin/UI/Settings.bsml
+++ b/CustomFloorPlugin/UI/Settings.bsml
@@ -3,4 +3,5 @@
   <dropdown-list-setting text='Environment Override' value='env-ov' options='env-ovs'></dropdown-list-setting>
   <dropdown-list-setting text='Environment Arrangement' value='env-arr' options='env-arrs'></dropdown-list-setting>
   <bool-setting text='Show heart' value='show-heart' hover-hint='Makes the heart, that Custom Platforms uses to generate most lights, visible in the menu'></bool-setting>
+  <clickable-text text='Refresh platforms' on-click='refresh-platforms'></clickable-text>
 </settings-container>

--- a/CustomFloorPlugin/UI/Settings.cs
+++ b/CustomFloorPlugin/UI/Settings.cs
@@ -8,10 +8,17 @@ namespace CustomFloorPlugin.UI {
         [UIParams]
         public BSMLParserParams parserParams;
 #pragma warning restore CS0649
+
+        /// <summary>
+        /// Reloads all platforms and updates the UI accordingly.
+        /// </summary>
         [UIAction("refresh-platforms")]
         private void refreshPlatforms()
         {
+            // Reload all platforms.
             PlatformManager.Instance.RefreshPlatforms();
+
+            // Update the UI.
             PlatformUI._platformMenuFlowCoordinator.RefreshPlatformsList();
         }
         [UIValue("always-show-feet")]

--- a/CustomFloorPlugin/UI/Settings.cs
+++ b/CustomFloorPlugin/UI/Settings.cs
@@ -8,6 +8,12 @@ namespace CustomFloorPlugin.UI {
         [UIParams]
         public BSMLParserParams parserParams;
 #pragma warning restore CS0649
+        [UIAction("refresh-platforms")]
+        private void refreshPlatforms()
+        {
+            PlatformManager.Instance.RefreshPlatforms();
+            PlatformUI._platformMenuFlowCoordinator.RefreshPlatformsList();
+        }
         [UIValue("always-show-feet")]
         public bool alwaysShowFeet {
             get {


### PR DESCRIPTION
I added a button to refresh platforms to mod settings, so you don't have to restart the game to get new/changed platforms.

`RotationEventEffectManager` has been fixed, and along with it, I've included a fix for a bug in the base game where the `_startRotation` was storing the global rotation when it should have been the local rotation.

`PairRotationEventEffectManager` has been added and is similar to the normal `RotationEventEffectManager`, however, this lets you specify a left and right laser to rotate in sync when laser speed events for both sides fire at the same time. This is the component used in most of the base game platforms. The same bug in the base game has been fixed here as well. I'm not sure how the .dll included in the original Custom Platforms unity project was created, but for 3D modelers to use this new feature, it'll have to be updated to include the behaviour descriptor.